### PR TITLE
Add higher near value

### DIFF
--- a/NearClippingPlaneAdjuster/NearClippingPlaneAdjuster.cs
+++ b/NearClippingPlaneAdjuster/NearClippingPlaneAdjuster.cs
@@ -15,7 +15,7 @@ namespace NearClipPlaneAdj
         {
             ExpansionKitApi.RegisterSimpleMenuButton(ExpandedMenu.SettingsMenu, "Nearplane-0.01", (() => ChangeNearClipPlane(.01f)));
             ExpansionKitApi.RegisterSimpleMenuButton(ExpandedMenu.SettingsMenu, "Nearplane-0.001", (() => ChangeNearClipPlane(.001f)));
-            ExpansionKitApi.RegisterSimpleMenuButton(ExpandedMenu.SettingsMenu, "Nearplane-0.0001", (() => ChangeNearClipPlane(.0001f)));
+            ExpansionKitApi.RegisterSimpleMenuButton(ExpandedMenu.SettingsMenu, "Nearplane-0.05", (() => ChangeNearClipPlane(.05f)));
             MelonLogger.Log("Near Plane Adjust Init");
         }
 


### PR DESCRIPTION
I found that 0.01 is too small in some very large worlds, as it changes the far clipping plane too, as you know. The world I really notice this in is [Test Pilots](https://www.vrchat.com/home/launch?worldId=wrld_e4908cea-023b-4749-9ad7-a898b12996e7). I also have experienced crashing in some worlds with the smallest value of 0.0001, and I could not notice any clipping with 0.001 in the smallest avatar I could find. So, I propose swapping 0.0001 with 0.05 which is a common value I have seen in many worlds including Test Pilots. Open to alternatives. Thanks